### PR TITLE
Exportar el reporte en Google Drive

### DIFF
--- a/exportar-reporte-drive.txt
+++ b/exportar-reporte-drive.txt
@@ -1,0 +1,1 @@
+Exportar reporte con Goodle Drive


### PR DESCRIPTION
Los usuarios ya pueden hacer reportes sobre bugs a través de Google Drive