### PR TITLE
Se solucionó un error al iniciar sesión con LinkedIn

### DIFF
--- a/login-linkedin.txt
+++ b/login-linkedin.txt
@@ -1,0 +1,1 @@
+Arreglamos el error de inicio de sesion con LinkedIn.


### PR DESCRIPTION
Los usuarios reportaron que se creaban dos perfiles diferentes al iniciar sesión por primera vez. Se ha solucionado.